### PR TITLE
Bump google sheets client (close #209)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,15 +14,15 @@
 import com.typesafe.sbt.packager.docker._
 
 lazy val baseSettings = Seq(
-  scalacOptions in (Compile, console) ~= {
+  scalacOptions in(Compile, console) ~= {
     _.filterNot(Set("-Ywarn-unused-import"))
   },
-  scalacOptions in (Test, console) ~= {
+  scalacOptions in(Test, console) ~= {
     _.filterNot(Set("-Ywarn-unused-import"))
   },
   organization := "com.snowplowanalytics",
   scalaVersion := "2.12.8",
-  version := "0.2.0",
+  version := "0.2.1",
   name := "cla-bot",
   licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 )
@@ -40,6 +40,9 @@ lazy val gsheeets4sVersion = "0.2.0"
 lazy val logbackVersion = "1.2.3"
 lazy val specs2Version = "4.6.0"
 lazy val mockitoVersion = "0.3.0"
+lazy val oauthVersion = "1.3.0"
+lazy val gapiVersion = "v4-rev581-1.25.0"
+
 
 lazy val claBot = project.in(file("."))
   .enablePlugins(JavaServerAppPackaging)
@@ -51,13 +54,14 @@ lazy val claBot = project.in(file("."))
       "org.http4s" %% "http4s-blaze-server",
       "org.http4s" %% "http4s-circe",
     ).map(_ % http4sVersion) ++ Seq(
+      "com.google.auth" % "google-auth-library-oauth2-http" % oauthVersion,
+      "com.google.apis" % "google-api-services-sheets" % gapiVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-config" % circeConfigVersion,
       "com.47deg" %% "github4s-cats-effect" % github4sVersion,
-      "com.github.benfradet" %% "gsheets4s" % gsheeets4sVersion,
-      "ch.qos.logback" % "logback-classic" % logbackVersion,
+      "ch.qos.logback" % "logback-classic" % logbackVersion
     ) ++ Seq(
       "org.specs2" %% "specs2-core",
-      "org.specs2" %% "specs2-mock",
+      "org.specs2" %% "specs2-mock"
     ).map(_ % specs2Version % "test")
   )

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,12 +6,8 @@ github {
   token = GITHUB_TOKEN
 }
 
-gsheets {
-  clientId     = GOOGLE_SHEETS_CLIENT_ID
-  clientSecret = GOOGLE_SHEETS_CLIENT_SECRET
-  accessToken  = GOOGLE_ACCESS_TOKEN
-  refreshToken = GOOGLE_REFRESH_TOKEN
-}
+
+oathCredPath = PATH_TO_CRED_JSON
 
 cla {
   individualCLA {
@@ -19,7 +15,7 @@ cla {
     spreadsheetId = GOOGLE_SPREADSHEET_ID
     sheetName     = GOOGLE_SPREADSHEET_NAME
     # columns containing GitHub logins
-    columns        = [ A ]
+    columns        = [ A, B ]
   }
   corporateCLA {
     # id of the spreadsheet (the one from the spreadsheet URL)

--- a/src/main/scala/clabot/GithubService.scala
+++ b/src/main/scala/clabot/GithubService.scala
@@ -69,7 +69,8 @@ class GithubServiceImpl[F[_]: Sync](token: String) extends GithubService[F] {
     gh.repos.listCollaborators(repo.owner.login, repo.name)
       .exec[F, HttpResponse[String]]()
       .flatMap(extractResult)
-      .map(users => users.map(_.login).find(_ === user.login))
+      .map(users => users.map(_.login)
+        .find(_ === user.login))
 }
 
 object GithubService {

--- a/src/main/scala/clabot/config.scala
+++ b/src/main/scala/clabot/config.scala
@@ -13,38 +13,30 @@
 package clabot
 
 import cats.data.NonEmptyList
-import gsheets4s.model.Credentials
 
 object config {
 
   final case class GithubConfig(token: String)
 
   final case class GoogleSheet(
-    spreadsheetId: String,
-    sheetName: String,
-    columns: NonEmptyList[String]
-  )
-
-  final case class CLAConfig(
-    individualCLA: GoogleSheet,
-    corporateCLA: GoogleSheet,
-    peopleToIgnore: List[String]
-  )
-
-  final case class GSheetsConfig(
-    accessToken: String,
-    refreshToken: String,
-    clientId: String,
-    clientSecret: String
-  ) {
-    def toCredentials: Credentials = Credentials(accessToken, refreshToken, clientId, clientSecret)
+                                spreadsheetId: String,
+                                sheetName: String,
+                                columns: NonEmptyList[String]
+                              ) {
+    def range: List[String] = columns.map(col => s"$sheetName!$col:$col").toList
   }
 
+  final case class CLAConfig(
+                              individualCLA: GoogleSheet,
+                              corporateCLA: GoogleSheet,
+                              peopleToIgnore: List[String]
+                            )
+
   final case class CLABotConfig(
-    port: Int,
-    host: String,
-    github: GithubConfig,
-    gsheets: GSheetsConfig,
-    cla: CLAConfig
-  )
+                                 port: Int,
+                                 host: String,
+                                 github: GithubConfig,
+                                 oathCredPath: String,
+                                 cla: CLAConfig
+                               )
 }


### PR DESCRIPTION
New java client on `google-auth-library-oauth2-http` and `google-api-services-sheets` for google sheets.

Config property `gsheets` had been removed and replaced with `oathCredPath` that should contain a path the service account `credentials.json` file.

TODO list for deployment
[ ] Create cla-bot service account in prod
[ ] Grant that account access to Google Sheets in config
[ ] Enable Gsheets API in prod
[ ] Test localy with real credentials.
[ ] Put base64 encoded json payload to Vault
[ ] Merge [this](https://github.com/snowplow-devops/terraform-modules/pull/3147) terraform change and deploy it.